### PR TITLE
Create .editorconfig for consistent code formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.{rs,toml,md,ex,exs,html,css,js,sh}]
+charset = utf-8
+trim_trailing_whitespace = true
+max_line_length = 120  # Recommended by github for better PR diffs
+
+# Two spaces for indentation
+[*.{ex,exs,html}]
+indent_style = space
+indent_size = 2
+
+# Four spaces for indentation
+[*.{sh,rs}]
+indent_style = space
+indent_size = 4
+
+[*.rs]
+rustfmt = true


### PR DESCRIPTION
Add .editorconfig to enforce coding styles and formatting.
my vscode display trailing white spaces:
<img width="618" height="764" alt="image" src="https://github.com/user-attachments/assets/a9026880-f037-4ded-bd5f-c05d2a093ddc" />
